### PR TITLE
Scope lib directories in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,8 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
-lib64/
+/lib/
+/lib64/
 parts/
 sdist/
 var/


### PR DESCRIPTION
## Summary
- Limit `lib` and `lib64` ignore patterns to the repository root

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689775853b18832e941fc6ff2397b9f6